### PR TITLE
🔒 Fix Path Traversal in PDF Generation

### DIFF
--- a/htmlPdfConverter.php
+++ b/htmlPdfConverter.php
@@ -33,6 +33,9 @@ function fileCreate($preName, $html){
     // Output the PDF to the browser
     $randomCode = str_pad(mt_rand(0, 999999), 6, '0', STR_PAD_LEFT);
 
+    $preName = basename($preName);
+    $preName = str_replace(array('/', '\\'), '', $preName);
+
     $outputFilePath = $preName."".$randomCode.'.pdf';
     file_put_contents($outputFilePath, $dompdf->output());
     return $outputFilePath;

--- a/tests/HtmlPdfConverterTest.php
+++ b/tests/HtmlPdfConverterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../htmlPdfConverter.php';
+
+class HtmlPdfConverterTest extends TestCase
+{
+    public function testFileCreateSanitizesPreName()
+    {
+        $preName = "../../../etc/passwd";
+        $html = "<html><body>Test</body></html>";
+
+        // Prevent fileCreate from actually rendering and writing a pdf
+        // Instead, we will simulate it by mocking file_put_contents or we can just let it create the file and assert its path
+        // Since we are creating a test file, let's just observe the returned path
+
+        $returnedPath = fileCreate($preName, $html);
+
+        // the returned path should just be passwd + random code + .pdf
+        $this->assertStringStartsWith('passwd', $returnedPath);
+        $this->assertStringNotContainsString('../', $returnedPath);
+        $this->assertStringNotContainsString('etc', $returnedPath);
+
+        // clean up
+        if (file_exists($returnedPath)) {
+            unlink($returnedPath);
+        }
+    }
+
+    public function testFileCreateSanitizesSlashes()
+    {
+        $preName = "valid/name\\here";
+        $html = "<html><body>Test</body></html>";
+
+        $returnedPath = fileCreate($preName, $html);
+
+        // basename will reduce "valid/name\here" to "name\here" or "here" depending on OS, then we strip slashes
+        // let's just assert no slashes are in the final name
+        $this->assertStringNotContainsString('/', $returnedPath);
+        $this->assertStringNotContainsString('\\', $returnedPath);
+
+        // clean up
+        if (file_exists($returnedPath)) {
+            unlink($returnedPath);
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Fixed a Path Traversal vulnerability in `htmlPdfConverter.php` where the `$preName` variable could contain directory traversal characters.
⚠️ **Risk:** An attacker could potentially write PDF files to arbitrary directories on the server by supplying crafted buyer names, leading to unauthorized file creation or overwriting.
🛡️ **Solution:** Applied `basename()` to `$preName` and explicitly stripped any remaining forward or backward slashes to ensure the resulting filename only contains the base name component, confining it safely to the current directory.

---
*PR created automatically by Jules for task [2379288133536065195](https://jules.google.com/task/2379288133536065195) started by @AdarshaCR001*