### PR TITLE
🎨 Palette: Add contextual ARIA labels and missing form label

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-06-13 - [Custom Validation, Loading States, and Modal Accessibility]
 **Learning:** Found that custom validation using jQuery is needed to prevent default browser validation UI from showing up. Also learned that when using SweetAlert for confirmations, moving the button state change into the `.then(result => { if (result.isConfirmed) { ... } })` block is safer than changing it beforehand, otherwise you need to handle the state reset in the `else` block if the user cancels.
 **Action:** When adding validation or loading states to jQuery-based forms, always set `novalidate` on the form tag to suppress the browser UI, and carefully scope the loading state updates to the confirmed path of any prompt dialogs.
+
+## 2026-06-13 - [Contextual ARIA Labels for Table Actions]
+**Learning:** Repetitive table action buttons (like 'Edit' or 'Download') on their own lack enough context for screen reader users when navigating tables.
+**Action:** Always append contextual information, such as the relevant ID or name, using `aria-label` (e.g., `aria-label="Edit invoice [ID]"`) to disambiguate table action buttons.

--- a/bills.php
+++ b/bills.php
@@ -844,11 +844,11 @@ function getPaginationLink($p, $buyer_filter, $balance_filter) {
                     <td><?php echo formatIndianCurrency($row['vehicle_freight']); ?></td>
                     <td>
                         <div style="font-weight: 600; margin-bottom: 6px;"><?php echo formatIndianCurrency($row['balance'] !== null ? $row['balance'] : 0.00); ?></div>
-                        <button class="btn btn-info" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
+                        <button class="btn btn-info" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" aria-label="Edit balance for invoice <?php echo htmlspecialchars($row['invoice_number']); ?>" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
                     </td>
                     <td class="actions-cell">
-                        <a class="file-download" href="<?php echo $row['url']; ?>" target="_blank" download>Download</a>
-                        <button class="btn btn-warning" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
+                        <a class="file-download" href="<?php echo $row['url']; ?>" target="_blank" download aria-label="Download invoice <?php echo htmlspecialchars($row['invoice_number']); ?>">Download</a>
+                        <button class="btn btn-warning" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)" aria-label="Edit invoice <?php echo htmlspecialchars($row['invoice_number']); ?>">Edit</button>
                     </td>
                 </tr>
             <?php } ?>

--- a/buyers.php
+++ b/buyers.php
@@ -606,7 +606,7 @@ try {
                     <span class="badge" style="background-color: var(--primary); font-size: 12px; font-weight: 600; padding: 4px 10px;"><?php echo htmlspecialchars($row['invoices_count']); ?></span>
                 </td>
                 <td class="actions-cell">
-                    <button class="btn btn-warning" onclick="editBuyer(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
+                    <button class="btn btn-warning" onclick="editBuyer(<?php echo htmlspecialchars(json_encode($row)); ?>)" aria-label="Edit buyer <?php echo htmlspecialchars($row['buyer_company']); ?>">Edit</button>
                 </td>
             </tr>
         <?php } ?>

--- a/login.php
+++ b/login.php
@@ -88,7 +88,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div class="error-message"><?php echo htmlspecialchars($error); ?></div>
         <?php endif; ?>
         <form method="POST">
-            <input type="password" name="password" class="form-control" placeholder="Enter Password" required>
+            <label for="password" class="sr-only" style="position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0;">Password</label>
+            <input type="password" id="password" name="password" class="form-control" placeholder="Enter Password" required>
             <button type="submit" class="btn btn-primary">Login</button>
         </form>
     </div>


### PR DESCRIPTION
🎨 Palette: Add contextual ARIA labels and missing form label

💡 What:
- Added contextual `aria-label` attributes to the action buttons ("Edit Balance", "Edit", "Download") in `bills.php` and `buyers.php`.
- Added a visually hidden, screen-reader-only `<label>` for the password input in `login.php`.

🎯 Why:
- Repetitive table action buttons lacked sufficient context for screen reader users (e.g., "Edit" vs "Edit invoice 123"). Contextual labels resolve this.
- Form inputs require an associated `<label>` to meet basic accessibility standards. The `sr-only` class ensures the visual design remains unchanged while providing necessary support.

♿ Accessibility:
- Significant improvements to screen reader navigation within tables and the login form.

---
*PR created automatically by Jules for task [15413815720737209483](https://jules.google.com/task/15413815720737209483) started by @AdarshaCR001*