### PR TITLE
🎨 Palette: Improve login form accessibility with sr-only label and autocomplete

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-06-13 - [Custom Validation, Loading States, and Modal Accessibility]
 **Learning:** Found that custom validation using jQuery is needed to prevent default browser validation UI from showing up. Also learned that when using SweetAlert for confirmations, moving the button state change into the `.then(result => { if (result.isConfirmed) { ... } })` block is safer than changing it beforehand, otherwise you need to handle the state reset in the `else` block if the user cancels.
 **Action:** When adding validation or loading states to jQuery-based forms, always set `novalidate` on the form tag to suppress the browser UI, and carefully scope the loading state updates to the confirmed path of any prompt dialogs.
+## 2026-06-14 - Accessible Labels and Autocomplete on Login
+**Learning:** Adding screen-reader only labels using Bootstrap's `sr-only` class alongside the `autocomplete` attribute significantly improves accessibility and usability of simple forms like login, without altering the visual design at all.
+**Action:** Always ensure that form inputs have associated `<label>` tags (even if visually hidden via `sr-only`) and appropriate `autocomplete` attributes (e.g. `current-password`) to aid assistive technologies and password managers.

--- a/login.php
+++ b/login.php
@@ -88,7 +88,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div class="error-message"><?php echo htmlspecialchars($error); ?></div>
         <?php endif; ?>
         <form method="POST">
-            <input type="password" name="password" class="form-control" placeholder="Enter Password" required>
+            <label for="password" class="sr-only">Password</label>
+            <input type="password" id="password" name="password" class="form-control" placeholder="Enter Password" required autocomplete="current-password">
             <button type="submit" class="btn btn-primary">Login</button>
         </form>
     </div>


### PR DESCRIPTION
💡 What: Added an `sr-only` accessible label and `autocomplete="current-password"` to the password input on the login form.
🎯 Why: To improve screen reader accessibility by providing a clear label for the password field, and to enhance usability by supporting password managers and browser autofill features.
📸 Before/After: Visuals remain unchanged due to the `sr-only` class.
♿ Accessibility: The `<input>` now has an associated `<label>` (linked via `id`), which is crucial for users relying on screen readers. Password manager support is also significantly improved.

---
*PR created automatically by Jules for task [2805817164778274309](https://jules.google.com/task/2805817164778274309) started by @AdarshaCR001*