### PR TITLE
🎨 Palette: Add contextual ARIA labels to data table action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-06-13 - [Custom Validation, Loading States, and Modal Accessibility]
 **Learning:** Found that custom validation using jQuery is needed to prevent default browser validation UI from showing up. Also learned that when using SweetAlert for confirmations, moving the button state change into the `.then(result => { if (result.isConfirmed) { ... } })` block is safer than changing it beforehand, otherwise you need to handle the state reset in the `else` block if the user cancels.
 **Action:** When adding validation or loading states to jQuery-based forms, always set `novalidate` on the form tag to suppress the browser UI, and carefully scope the loading state updates to the confirmed path of any prompt dialogs.
+
+## 2026-06-13 - [Data Table Action Button Accessibility]
+**Learning:** Found that repeated action buttons inside data tables (like "Edit" or "Download") create a poor screen reader experience because they lack context ("Edit", "Edit", "Edit").
+**Action:** Always add contextual `aria-label` attributes to action buttons inside data tables, incorporating the unique identifier or name from that specific row (e.g., `aria-label="Edit invoice 1024"`).

--- a/bills.php
+++ b/bills.php
@@ -844,11 +844,11 @@ function getPaginationLink($p, $buyer_filter, $balance_filter) {
                     <td><?php echo formatIndianCurrency($row['vehicle_freight']); ?></td>
                     <td>
                         <div style="font-weight: 600; margin-bottom: 6px;"><?php echo formatIndianCurrency($row['balance'] !== null ? $row['balance'] : 0.00); ?></div>
-                        <button class="btn btn-info" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
+                        <button class="btn btn-info" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" aria-label="Edit balance for invoice <?php echo htmlspecialchars($row['invoice_number']); ?>" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
                     </td>
                     <td class="actions-cell">
-                        <a class="file-download" href="<?php echo $row['url']; ?>" target="_blank" download>Download</a>
-                        <button class="btn btn-warning" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
+                        <a class="file-download" href="<?php echo $row['url']; ?>" target="_blank" download aria-label="Download invoice <?php echo htmlspecialchars($row['invoice_number']); ?>">Download</a>
+                        <button class="btn btn-warning" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)" aria-label="Edit invoice <?php echo htmlspecialchars($row['invoice_number']); ?>">Edit</button>
                     </td>
                 </tr>
             <?php } ?>

--- a/buyers.php
+++ b/buyers.php
@@ -606,7 +606,7 @@ try {
                     <span class="badge" style="background-color: var(--primary); font-size: 12px; font-weight: 600; padding: 4px 10px;"><?php echo htmlspecialchars($row['invoices_count']); ?></span>
                 </td>
                 <td class="actions-cell">
-                    <button class="btn btn-warning" onclick="editBuyer(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
+                    <button class="btn btn-warning" onclick="editBuyer(<?php echo htmlspecialchars(json_encode($row)); ?>)" aria-label="Edit buyer <?php echo htmlspecialchars($row['buyer_company']); ?>">Edit</button>
                 </td>
             </tr>
         <?php } ?>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the "Edit Balance", "Download", and "Edit" buttons in `bills.php`, and the "Edit" button in `buyers.php`.
🎯 Why: Screen reader users previously heard repetitive labels like "Edit", "Edit", "Edit" without context of which row they belonged to. The new labels provide context (e.g., "Edit invoice 1024", "Edit buyer Acme Corp").
♿ Accessibility: Improves navigation and action clarity for screen reader users when interacting with data tables.

---
*PR created automatically by Jules for task [11270897007748773214](https://jules.google.com/task/11270897007748773214) started by @AdarshaCR001*