### PR TITLE
🛡️ Sentinel: [HIGH] Fix persistent XSS in bills table

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Persistent XSS in Data Tables
+**Vulnerability:** Persistent Cross-Site Scripting (XSS) in `bills.php`. User-controlled fields like `invoice_number`, `buyer_company`, `buyer_address`, `item_name`, etc. were directly echoed in the HTML without sanitization.
+**Learning:** Legacy PHP codebases frequently miss context-aware output encoding. While SQL injection was prevented using PDO prepared statements, outputting database contents directly back into the UI allowed for stored XSS.
+**Prevention:** Always use `htmlspecialchars()` with appropriate flags or a dedicated templating engine that auto-escapes output when rendering user-generated content in HTML contexts.

--- a/bills.php
+++ b/bills.php
@@ -831,23 +831,23 @@ function getPaginationLink($p, $buyer_filter, $balance_filter) {
                 <?php if (count($result) > 0) { ?>
             <?php foreach ($result as $row) { ?>
                 <tr>
-                    <td><?php echo $row['invoice_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['invoice_number'] ?? ''); ?></td>
                     <td><?php echo htmlspecialchars(date('Y-m-d', strtotime($row['created_on']))); ?></td>
-                    <td><?php echo $row['buyer_company']; ?></td>
-                    <td><?php echo $row['buyer_address']; ?></td>
-                    <td><?php echo $row['item_name']; ?></td>
-                    <td><?php echo $row['bag']; ?></td>
-                    <td><?php echo $row['quantity']; ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_company'] ?? ''); ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_address'] ?? ''); ?></td>
+                    <td><?php echo htmlspecialchars($row['item_name'] ?? ''); ?></td>
+                    <td><?php echo htmlspecialchars($row['bag'] ?? ''); ?></td>
+                    <td><?php echo htmlspecialchars($row['quantity'] ?? ''); ?></td>
                     <td><?php echo formatIndianCurrency($row['price']); ?></td>
                     <td><?php echo formatIndianCurrency($row['price'] * $row['quantity']); ?></td>
-                    <td><?php echo $row['vehicle_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['vehicle_number'] ?? ''); ?></td>
                     <td><?php echo formatIndianCurrency($row['vehicle_freight']); ?></td>
                     <td>
                         <div style="font-weight: 600; margin-bottom: 6px;"><?php echo formatIndianCurrency($row['balance'] !== null ? $row['balance'] : 0.00); ?></div>
                         <button class="btn btn-info" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
                     </td>
                     <td class="actions-cell">
-                        <a class="file-download" href="<?php echo $row['url']; ?>" target="_blank" download>Download</a>
+                        <a class="file-download" href="<?php echo htmlspecialchars($row['url'] ?? ''); ?>" target="_blank" download>Download</a>
                         <button class="btn btn-warning" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
                     </td>
                 </tr>


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Persistent Cross-Site Scripting (XSS) in `bills.php`. Several user-controlled fields (`invoice_number`, `buyer_company`, `buyer_address`, `item_name`, `bag`, `quantity`, `vehicle_number`, `url`) were directly echoed into the HTML table without proper output encoding.
🎯 **Impact:** An attacker who successfully injects malicious scripts into the database (e.g., via the buyer management or bill creation forms) could execute arbitrary JavaScript in the browsers of all users viewing the bills list. This could lead to session hijacking, data theft, or unauthorized actions performed on behalf of the victim.
🔧 **Fix:** Wrapped the vulnerable direct outputs with `htmlspecialchars()`. Used the null coalescing operator (`?? ''`) to ensure `null` values don't trigger deprecation warnings in newer PHP versions.
✅ **Verification:** Verify by running the test suite (`./vendor/bin/phpunit tests/`) and loading the `bills.php` page in the browser after creating a bill with a payload like `<script>alert('xss')</script>` in the item name. The payload should be rendered as text, not executed as a script.

---
*PR created automatically by Jules for task [648535425591445515](https://jules.google.com/task/648535425591445515) started by @AdarshaCR001*