### PR TITLE
🎨 Palette: Add aria-labels to table action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-06-13 - [Custom Validation, Loading States, and Modal Accessibility]
 **Learning:** Found that custom validation using jQuery is needed to prevent default browser validation UI from showing up. Also learned that when using SweetAlert for confirmations, moving the button state change into the `.then(result => { if (result.isConfirmed) { ... } })` block is safer than changing it beforehand, otherwise you need to handle the state reset in the `else` block if the user cancels.
 **Action:** When adding validation or loading states to jQuery-based forms, always set `novalidate` on the form tag to suppress the browser UI, and carefully scope the loading state updates to the confirmed path of any prompt dialogs.
+
+## 2024-05-18 - [Table Action Button Accessibility]
+**Learning:** Data tables often repeat generic action buttons (like "Edit" or "Download") on every row. Screen reader users navigating out of context will just hear the generic text repeatedly, which violates WCAG guidelines.
+**Action:** When adding or reviewing action buttons in data tables, always add an `aria-label` attribute that includes a unique identifier for the row (like the item name, company name, or ID) to provide clear context for screen reader users.

--- a/bills.php
+++ b/bills.php
@@ -844,11 +844,11 @@ function getPaginationLink($p, $buyer_filter, $balance_filter) {
                     <td><?php echo formatIndianCurrency($row['vehicle_freight']); ?></td>
                     <td>
                         <div style="font-weight: 600; margin-bottom: 6px;"><?php echo formatIndianCurrency($row['balance'] !== null ? $row['balance'] : 0.00); ?></div>
-                        <button class="btn btn-info" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
+                        <button class="btn btn-info" aria-label="Edit balance for invoice <?php echo htmlspecialchars($row['invoice_number']); ?>" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
                     </td>
                     <td class="actions-cell">
-                        <a class="file-download" href="<?php echo $row['url']; ?>" target="_blank" download>Download</a>
-                        <button class="btn btn-warning" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
+                        <a class="file-download" aria-label="Download invoice <?php echo htmlspecialchars($row['invoice_number']); ?>" href="<?php echo $row['url']; ?>" target="_blank" download>Download</a>
+                        <button class="btn btn-warning" aria-label="Edit invoice <?php echo htmlspecialchars($row['invoice_number']); ?>" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
                     </td>
                 </tr>
             <?php } ?>

--- a/buyers.php
+++ b/buyers.php
@@ -606,7 +606,7 @@ try {
                     <span class="badge" style="background-color: var(--primary); font-size: 12px; font-weight: 600; padding: 4px 10px;"><?php echo htmlspecialchars($row['invoices_count']); ?></span>
                 </td>
                 <td class="actions-cell">
-                    <button class="btn btn-warning" onclick="editBuyer(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
+                    <button class="btn btn-warning" aria-label="Edit buyer <?php echo htmlspecialchars($row['buyer_company']); ?>" onclick="editBuyer(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
                 </td>
             </tr>
         <?php } ?>


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` attributes to the "Edit Balance", "Download", and "Edit" action buttons in the `bills.php` and `buyers.php` data tables.

🎯 Why: To fix an accessibility issue (WCAG 2.4.4) where screen reader users navigating buttons out of context would only hear repetitive, generic text like "Edit" or "Download". Now they will hear contextual labels like "Edit invoice 1" or "Edit buyer Acme Corp".

📸 Before/After: Visual UI remains unchanged (invisible a11y improvement).
♿ Accessibility: Improved screen reader navigation and context for data table actions.

---
*PR created automatically by Jules for task [16834876824211126282](https://jules.google.com/task/16834876824211126282) started by @AdarshaCR001*