### PR TITLE
🎨 Palette: Add login loading state and autofocus

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-06-13 - [Custom Validation, Loading States, and Modal Accessibility]
 **Learning:** Found that custom validation using jQuery is needed to prevent default browser validation UI from showing up. Also learned that when using SweetAlert for confirmations, moving the button state change into the `.then(result => { if (result.isConfirmed) { ... } })` block is safer than changing it beforehand, otherwise you need to handle the state reset in the `else` block if the user cancels.
 **Action:** When adding validation or loading states to jQuery-based forms, always set `novalidate` on the form tag to suppress the browser UI, and carefully scope the loading state updates to the confirmed path of any prompt dialogs.
+## 2026-06-19 - [Single-Input Standalone Forms UX]
+**Learning:** Found that single-input standalone pages (like login forms) greatly benefit from `autofocus` and inline vanilla JS state management. This provides immediate focus without manual clicking and a simple loading state, bridging the micro-UX gap without needing heavy dependencies like jQuery.
+**Action:** Always consider adding `autofocus` and a lightweight vanilla JS loading state to simple, critical forms (like login) to instantly improve perceived performance and accessibility.

--- a/login.php
+++ b/login.php
@@ -87,8 +87,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <?php if ($error): ?>
             <div class="error-message"><?php echo htmlspecialchars($error); ?></div>
         <?php endif; ?>
-        <form method="POST">
-            <input type="password" name="password" class="form-control" placeholder="Enter Password" required>
+        <form method="POST" onsubmit="var b=this.querySelector('button[type=submit]'); b.disabled=true; b.innerHTML='Logging in...';">
+            <input type="password" id="password" name="password" class="form-control" placeholder="Enter Password" aria-label="Password" required autofocus>
             <button type="submit" class="btn btn-primary">Login</button>
         </form>
     </div>


### PR DESCRIPTION
### 💡 What
Added a loading state and autofocus to the login form, along with improved screen reader accessibility.

### 🎯 Why
The login page is a single-input form that users interact with frequently. Adding `autofocus` removes the need for an initial click to start typing, significantly improving the time-to-interact. The inline vanilla JS loading state prevents double-submissions and provides immediate visual feedback that authentication is occurring, without requiring heavy dependencies like jQuery on a lightweight page.

### ♿ Accessibility
- Added `aria-label="Password"` to the input field, as the form previously lacked an explicit `<label>`, making it clear to screen readers what the input is for.
- Added an `id="password"` to the input field.

### 📸 Verification
The changes have been tested locally via a Playwright script to verify the autofocus state, the "Logging in..." button state upon submission, and PHPUnit tests all pass successfully.

---
*PR created automatically by Jules for task [11594082663371880947](https://jules.google.com/task/11594082663371880947) started by @AdarshaCR001*