### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in bills data output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-18 - Missing Output Sanitization in bills.php
+**Vulnerability:** Found multiple instances in `bills.php` where user-controlled inputs such as `invoice_number`, `buyer_company`, `buyer_address`, `item_name`, `bag`, `quantity`, `vehicle_number`, and `url` were echoed directly to the HTML page without proper escaping.
+**Learning:** This exposes the application to Persistent Cross-Site Scripting (XSS). When rendering output from the database that originates from user input, we must strictly validate or sanitize it to prevent script injection.
+**Prevention:** Always use `htmlspecialchars()` when rendering string variables in HTML templates.

--- a/bills.php
+++ b/bills.php
@@ -831,23 +831,23 @@ function getPaginationLink($p, $buyer_filter, $balance_filter) {
                 <?php if (count($result) > 0) { ?>
             <?php foreach ($result as $row) { ?>
                 <tr>
-                    <td><?php echo $row['invoice_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['invoice_number']); ?></td>
                     <td><?php echo htmlspecialchars(date('Y-m-d', strtotime($row['created_on']))); ?></td>
-                    <td><?php echo $row['buyer_company']; ?></td>
-                    <td><?php echo $row['buyer_address']; ?></td>
-                    <td><?php echo $row['item_name']; ?></td>
-                    <td><?php echo $row['bag']; ?></td>
-                    <td><?php echo $row['quantity']; ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_company']); ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_address']); ?></td>
+                    <td><?php echo htmlspecialchars($row['item_name']); ?></td>
+                    <td><?php echo htmlspecialchars($row['bag']); ?></td>
+                    <td><?php echo htmlspecialchars($row['quantity']); ?></td>
                     <td><?php echo formatIndianCurrency($row['price']); ?></td>
                     <td><?php echo formatIndianCurrency($row['price'] * $row['quantity']); ?></td>
-                    <td><?php echo $row['vehicle_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['vehicle_number']); ?></td>
                     <td><?php echo formatIndianCurrency($row['vehicle_freight']); ?></td>
                     <td>
                         <div style="font-weight: 600; margin-bottom: 6px;"><?php echo formatIndianCurrency($row['balance'] !== null ? $row['balance'] : 0.00); ?></div>
                         <button class="btn btn-info" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
                     </td>
                     <td class="actions-cell">
-                        <a class="file-download" href="<?php echo $row['url']; ?>" target="_blank" download>Download</a>
+                        <a class="file-download" href="<?php echo htmlspecialchars($row['url']); ?>" target="_blank" download>Download</a>
                         <button class="btn btn-warning" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
                     </td>
                 </tr>


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-controlled inputs such as `invoice_number`, `buyer_company`, `buyer_address`, `item_name`, `bag`, `quantity`, `vehicle_number`, and `url` were echoed directly into HTML without escaping in `bills.php`. This allows for Persistent Cross-Site Scripting (XSS).
🎯 Impact: Malicious actors could inject malicious `<script>` payloads into database fields (e.g., during the merge or bill creation processes if left unchecked) which would then execute when a user visits the bills page.
🔧 Fix: Wrapped these specific output variables in `htmlspecialchars()` to escape potentially malicious scripts.
✅ Verification: Ran the PHP syntax check, PHPUnit tests, and performed frontend validation using Playwright with malicious inputs to confirm strings are properly escaped.

---
*PR created automatically by Jules for task [1347669567822118523](https://jules.google.com/task/1347669567822118523) started by @AdarshaCR001*