### PR TITLE
🎨 Palette: Add accessible label and loading state to login form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-06-13 - [Custom Validation, Loading States, and Modal Accessibility]
 **Learning:** Found that custom validation using jQuery is needed to prevent default browser validation UI from showing up. Also learned that when using SweetAlert for confirmations, moving the button state change into the `.then(result => { if (result.isConfirmed) { ... } })` block is safer than changing it beforehand, otherwise you need to handle the state reset in the `else` block if the user cancels.
 **Action:** When adding validation or loading states to jQuery-based forms, always set `novalidate` on the form tag to suppress the browser UI, and carefully scope the loading state updates to the confirmed path of any prompt dialogs.
+## 2026-06-22 - [Bootstrap 3 Utility Classes]
+**Learning:** Found that Bootstrap 3.3.7 already includes the `.sr-only` class for screen-reader accessibility, so there is no need to manually add custom CSS blocks for it.
+**Action:** When adding visually hidden labels for accessibility in Bootstrap 3 environments, leverage the built-in `.sr-only` class instead of writing custom CSS.

--- a/login.php
+++ b/login.php
@@ -87,8 +87,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <?php if ($error): ?>
             <div class="error-message"><?php echo htmlspecialchars($error); ?></div>
         <?php endif; ?>
-        <form method="POST">
-            <input type="password" name="password" class="form-control" placeholder="Enter Password" required>
+        <form method="POST" onsubmit="this.querySelector('button[type=submit]').disabled=true; this.querySelector('button[type=submit]').innerHTML='Logging in...';">
+            <label for="password" class="sr-only">Password</label>
+            <input type="password" name="password" id="password" aria-required="true" class="form-control" placeholder="Enter Password" required>
             <button type="submit" class="btn btn-primary">Login</button>
         </form>
     </div>


### PR DESCRIPTION
💡 **What:** Added an accessible `<label>` for the password input and a visual loading state to the login button on submission.
🎯 **Why:** To improve screen reader accessibility for the isolated password input field, and to provide immediate visual feedback while preventing duplicate form submissions.
♿ **Accessibility:** Added an explicitly associated `<label>` using the `sr-only` class to ensure the field is announced correctly by screen readers, along with `id` and `aria-required` attributes.

---
*PR created automatically by Jules for task [11198433187443358404](https://jules.google.com/task/11198433187443358404) started by @AdarshaCR001*