### PR TITLE
🎨 Palette: Add empty state to buyers list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-06-13 - [Custom Validation, Loading States, and Modal Accessibility]
 **Learning:** Found that custom validation using jQuery is needed to prevent default browser validation UI from showing up. Also learned that when using SweetAlert for confirmations, moving the button state change into the `.then(result => { if (result.isConfirmed) { ... } })` block is safer than changing it beforehand, otherwise you need to handle the state reset in the `else` block if the user cancels.
 **Action:** When adding validation or loading states to jQuery-based forms, always set `novalidate` on the form tag to suppress the browser UI, and carefully scope the loading state updates to the confirmed path of any prompt dialogs.
+
+## 2024-05-18 - Table Empty States in Vanilla PHP
+**Learning:** When adding empty states to standard HTML `<table>` elements without a frontend framework, wrapping the empty state message in a single `<tr>` with a `colspan` spanning all table headers ensures it renders correctly within the `<tbody>` structure without breaking the table layout.
+**Action:** Always verify the number of `<th>` elements in the table header and set the `colspan` of the empty state `<td>` to match, ensuring consistent layout across empty and populated states.

--- a/buyers.php
+++ b/buyers.php
@@ -596,17 +596,27 @@ try {
             </tr>
         </thead>
         <tbody>
-        <?php foreach ($result as $row) { ?>
+        <?php if (count($result) > 0) { ?>
+            <?php foreach ($result as $row) { ?>
+                <tr>
+                    <td><?php echo htmlspecialchars($row['id']); ?></td>
+                    <td style="font-weight: 600;"><?php echo htmlspecialchars($row['buyer_company']); ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_name'] ?: '-'); ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_address']); ?></td>
+                    <td style="text-align: center;">
+                        <span class="badge" style="background-color: var(--primary); font-size: 12px; font-weight: 600; padding: 4px 10px;"><?php echo htmlspecialchars($row['invoices_count']); ?></span>
+                    </td>
+                    <td class="actions-cell">
+                        <button class="btn btn-warning" onclick="editBuyer(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
+                    </td>
+                </tr>
+            <?php } ?>
+        <?php } else { ?>
             <tr>
-                <td><?php echo htmlspecialchars($row['id']); ?></td>
-                <td style="font-weight: 600;"><?php echo htmlspecialchars($row['buyer_company']); ?></td>
-                <td><?php echo htmlspecialchars($row['buyer_name'] ?: '-'); ?></td>
-                <td><?php echo htmlspecialchars($row['buyer_address']); ?></td>
-                <td style="text-align: center;">
-                    <span class="badge" style="background-color: var(--primary); font-size: 12px; font-weight: 600; padding: 4px 10px;"><?php echo htmlspecialchars($row['invoices_count']); ?></span>
-                </td>
-                <td class="actions-cell">
-                    <button class="btn btn-warning" onclick="editBuyer(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
+                <td colspan="6" style="text-align: center; color: var(--text-muted); padding: 40px;">
+                    <div style="font-size: 40px; margin-bottom: 10px;">👥</div>
+                    <div style="font-weight: 500; font-size: 16px; margin-bottom: 5px;">No buyers found</div>
+                    <div style="font-size: 13px;">Click "Add Buyer" above to create your first buyer.</div>
                 </td>
             </tr>
         <?php } ?>


### PR DESCRIPTION
💡 What: Added an empty state to the buyers table in `buyers.php` with a user-friendly message and icon.
🎯 Why: Provides helpful guidance ("Click 'Add Buyer' above to create your first buyer") when the table is empty, rather than just showing headers with no rows, improving intuitiveness.
📸 Before/After: Visuals verified via Playwright screenshot.
♿ Accessibility: Handled cleanly within table layout structure to ensure screen readers do not encounter broken table semantics.

---
*PR created automatically by Jules for task [2272763263201460298](https://jules.google.com/task/2272763263201460298) started by @AdarshaCR001*