### PR TITLE
🎨 Palette: Add autofocus and SR label to login

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-06-13 - [Custom Validation, Loading States, and Modal Accessibility]
 **Learning:** Found that custom validation using jQuery is needed to prevent default browser validation UI from showing up. Also learned that when using SweetAlert for confirmations, moving the button state change into the `.then(result => { if (result.isConfirmed) { ... } })` block is safer than changing it beforehand, otherwise you need to handle the state reset in the `else` block if the user cancels.
 **Action:** When adding validation or loading states to jQuery-based forms, always set `novalidate` on the form tag to suppress the browser UI, and carefully scope the loading state updates to the confirmed path of any prompt dialogs.
+
+## 2024-06-28 - [Add autofocus and SR label to login input]
+**Learning:** HTML `autofocus` combined with `<label class="sr-only">` significantly improves accessibility and UX for single-input login forms without visual clutter or extra JavaScript.
+**Action:** Use native HTML `autofocus` attribute for the primary input on specialized pages like logins, and ensure visually hidden labels use Bootstrap's `.sr-only` class for screen readers.

--- a/login.php
+++ b/login.php
@@ -88,7 +88,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div class="error-message"><?php echo htmlspecialchars($error); ?></div>
         <?php endif; ?>
         <form method="POST">
-            <input type="password" name="password" class="form-control" placeholder="Enter Password" required>
+            <label for="password" class="sr-only">Password</label>
+            <input type="password" id="password" name="password" class="form-control" placeholder="Enter Password" required autofocus>
             <button type="submit" class="btn btn-primary">Login</button>
         </form>
     </div>


### PR DESCRIPTION
💡 What: Added the `autofocus` attribute and an accessible screen-reader-only (`.sr-only`) `<label>` to the password input field on the `login.php` page. Appended a new entry to the `.Jules/palette.md` journal.
🎯 Why: To improve the user experience by saving a click on load, and to resolve accessibility warnings regarding form inputs missing associated labels.
♿ Accessibility: Improved keyboard focus and screen reader support (via the explicit label mapping with ID).

---
*PR created automatically by Jules for task [2738018039340689446](https://jules.google.com/task/2738018039340689446) started by @AdarshaCR001*