### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerabilities in bills.php

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-27 - [XSS Vulnerability in Direct Output]
+**Vulnerability:** Found direct echoes of database values (e.g. `$row['buyer_company']`, `$row['buyer_address']`, `$row['item_name']`, `$row['vehicle_number']`, `$row['url']`) inside HTML tags without proper sanitization. This is a severe Cross-Site Scripting (XSS) vulnerability.
+**Learning:** Even though the database interaction uses prepared statements (preventing SQL injection), developers often forget that values retrieved from the database and output back to the page must still be sanitized.
+**Prevention:** Always wrap variables output directly to the HTML document within `htmlspecialchars()` to encode special characters properly and prevent malicious scripts from executing in the browser.

--- a/bills.php
+++ b/bills.php
@@ -831,23 +831,23 @@ function getPaginationLink($p, $buyer_filter, $balance_filter) {
                 <?php if (count($result) > 0) { ?>
             <?php foreach ($result as $row) { ?>
                 <tr>
-                    <td><?php echo $row['invoice_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['invoice_number']); ?></td>
                     <td><?php echo htmlspecialchars(date('Y-m-d', strtotime($row['created_on']))); ?></td>
-                    <td><?php echo $row['buyer_company']; ?></td>
-                    <td><?php echo $row['buyer_address']; ?></td>
-                    <td><?php echo $row['item_name']; ?></td>
-                    <td><?php echo $row['bag']; ?></td>
-                    <td><?php echo $row['quantity']; ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_company']); ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_address']); ?></td>
+                    <td><?php echo htmlspecialchars($row['item_name']); ?></td>
+                    <td><?php echo htmlspecialchars($row['bag']); ?></td>
+                    <td><?php echo htmlspecialchars($row['quantity']); ?></td>
                     <td><?php echo formatIndianCurrency($row['price']); ?></td>
                     <td><?php echo formatIndianCurrency($row['price'] * $row['quantity']); ?></td>
-                    <td><?php echo $row['vehicle_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['vehicle_number']); ?></td>
                     <td><?php echo formatIndianCurrency($row['vehicle_freight']); ?></td>
                     <td>
                         <div style="font-weight: 600; margin-bottom: 6px;"><?php echo formatIndianCurrency($row['balance'] !== null ? $row['balance'] : 0.00); ?></div>
                         <button class="btn btn-info" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
                     </td>
                     <td class="actions-cell">
-                        <a class="file-download" href="<?php echo $row['url']; ?>" target="_blank" download>Download</a>
+                        <a class="file-download" href="<?php echo htmlspecialchars($row['url']); ?>" target="_blank" download>Download</a>
                         <button class="btn btn-warning" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
                     </td>
                 </tr>


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS vulnerabilities in bills.php

🚨 Severity: HIGH
💡 Vulnerability: Direct echoes of database values (`$row['buyer_company']`, `$row['buyer_address']`, `$row['item_name']`, `$row['vehicle_number']`, `$row['url']`) inside HTML tags in `bills.php` were missing sanitization, creating Cross-Site Scripting (XSS) risks.
🎯 Impact: Malicious actors could inject executable scripts into the database which would then be executed in the browsers of users viewing the bills table, leading to potential session hijacking or further attacks.
🔧 Fix: Wrapped the output variables with `htmlspecialchars()` to safely encode special HTML characters.
✅ Verification: Ran `php -l` and PHPUnit tests. Verified the outputs visually in the diff.

---
*PR created automatically by Jules for task [148456839824882792](https://jules.google.com/task/148456839824882792) started by @AdarshaCR001*