### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in Bills view

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-10-27 - [Stored XSS in Bills List view]
+**Vulnerability:** Several user-controlled database inputs (`buyer_company`, `item_name`, `vehicle_number`, etc.) were directly echoed into the HTML context in `bills.php` without escaping. Even though data comes from the database (via PDO prepared statements), it acts as a Stored XSS vulnerability if an attacker had managed to insert malicious scripts previously.
+**Learning:** Stored data is NOT inherently safe data. Just because data was safely stored using PDO prepared statements (preventing SQL injection) does not mean it is safe to render directly in HTML contexts.
+**Prevention:** Always use `htmlspecialchars()` when echoing any user-controlled data into HTML, even if that data was retrieved from the application's own database.

--- a/bills.php
+++ b/bills.php
@@ -831,23 +831,23 @@ function getPaginationLink($p, $buyer_filter, $balance_filter) {
                 <?php if (count($result) > 0) { ?>
             <?php foreach ($result as $row) { ?>
                 <tr>
-                    <td><?php echo $row['invoice_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['invoice_number']); ?></td>
                     <td><?php echo htmlspecialchars(date('Y-m-d', strtotime($row['created_on']))); ?></td>
-                    <td><?php echo $row['buyer_company']; ?></td>
-                    <td><?php echo $row['buyer_address']; ?></td>
-                    <td><?php echo $row['item_name']; ?></td>
-                    <td><?php echo $row['bag']; ?></td>
-                    <td><?php echo $row['quantity']; ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_company']); ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_address']); ?></td>
+                    <td><?php echo htmlspecialchars($row['item_name']); ?></td>
+                    <td><?php echo htmlspecialchars($row['bag']); ?></td>
+                    <td><?php echo htmlspecialchars($row['quantity']); ?></td>
                     <td><?php echo formatIndianCurrency($row['price']); ?></td>
                     <td><?php echo formatIndianCurrency($row['price'] * $row['quantity']); ?></td>
-                    <td><?php echo $row['vehicle_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['vehicle_number']); ?></td>
                     <td><?php echo formatIndianCurrency($row['vehicle_freight']); ?></td>
                     <td>
                         <div style="font-weight: 600; margin-bottom: 6px;"><?php echo formatIndianCurrency($row['balance'] !== null ? $row['balance'] : 0.00); ?></div>
                         <button class="btn btn-info" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
                     </td>
                     <td class="actions-cell">
-                        <a class="file-download" href="<?php echo $row['url']; ?>" target="_blank" download>Download</a>
+                        <a class="file-download" href="<?php echo htmlspecialchars($row['url']); ?>" target="_blank" download>Download</a>
                         <button class="btn btn-warning" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
                     </td>
                 </tr>


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Stored XSS. Several user-controlled data points (`buyer_company`, `item_name`, `vehicle_number`, etc.) retrieved from the database were directly echoed into the HTML context in `bills.php` without proper output escaping.
🎯 Impact: If an attacker manages to insert malicious scripts into the database (e.g., when creating a buyer or bill), the scripts would be executed in the browsers of users viewing the bills list.
🔧 Fix: Wrapped all such variables in `htmlspecialchars()` before echoing them out into the HTML context.
✅ Verification: Ran `php -l bills.php` to verify PHP syntax and successfully ran the PHPUnit test suite to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [2354346579357037506](https://jules.google.com/task/2354346579357037506) started by @AdarshaCR001*