### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerabilities in bills.php

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Cross-Site Scripting (XSS) Vulnerability in Bills Table
+**Vulnerability:** Several fields fetched from the database in `bills.php` (`buyer_company`, `buyer_address`, `item_name`, `bag`, `quantity`, `vehicle_number`, `url`) are directly echoed into the HTML output without being escaped.
+**Learning:** This occurs when data stored in the database is assumed to be safe. If an attacker injects a malicious payload into any of these fields (e.g., during bill creation/update or buyer creation), it will be executed when the `bills.php` page is viewed.
+**Prevention:** Always use `htmlspecialchars()` when rendering user-controlled data or data retrieved from the database in HTML contexts, even if it is believed to be safe.

--- a/bills.php
+++ b/bills.php
@@ -831,23 +831,23 @@ function getPaginationLink($p, $buyer_filter, $balance_filter) {
                 <?php if (count($result) > 0) { ?>
             <?php foreach ($result as $row) { ?>
                 <tr>
-                    <td><?php echo $row['invoice_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['invoice_number']); ?></td>
                     <td><?php echo htmlspecialchars(date('Y-m-d', strtotime($row['created_on']))); ?></td>
-                    <td><?php echo $row['buyer_company']; ?></td>
-                    <td><?php echo $row['buyer_address']; ?></td>
-                    <td><?php echo $row['item_name']; ?></td>
-                    <td><?php echo $row['bag']; ?></td>
-                    <td><?php echo $row['quantity']; ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_company']); ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_address']); ?></td>
+                    <td><?php echo htmlspecialchars($row['item_name']); ?></td>
+                    <td><?php echo htmlspecialchars($row['bag']); ?></td>
+                    <td><?php echo htmlspecialchars($row['quantity']); ?></td>
                     <td><?php echo formatIndianCurrency($row['price']); ?></td>
                     <td><?php echo formatIndianCurrency($row['price'] * $row['quantity']); ?></td>
-                    <td><?php echo $row['vehicle_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['vehicle_number']); ?></td>
                     <td><?php echo formatIndianCurrency($row['vehicle_freight']); ?></td>
                     <td>
                         <div style="font-weight: 600; margin-bottom: 6px;"><?php echo formatIndianCurrency($row['balance'] !== null ? $row['balance'] : 0.00); ?></div>
                         <button class="btn btn-info" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
                     </td>
                     <td class="actions-cell">
-                        <a class="file-download" href="<?php echo $row['url']; ?>" target="_blank" download>Download</a>
+                        <a class="file-download" href="<?php echo htmlspecialchars($row['url']); ?>" target="_blank" download>Download</a>
                         <button class="btn btn-warning" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
                     </td>
                 </tr>


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Cross-Site Scripting (XSS). User-controlled data retrieved from the database in `bills.php` (`buyer_company`, `buyer_address`, `item_name`, `bag`, `quantity`, `vehicle_number`, `url`) was being echoed directly into the HTML table without being escaped.
🎯 **Impact**: If an attacker were to inject a malicious payload into any of these fields, the script could be executed in the context of the user's browser viewing the bills page, potentially allowing session hijacking or unauthorized actions.
🔧 **Fix**: Wrapped the vulnerable echoed variables (and `invoice_number` for consistency) in `htmlspecialchars()` to ensure any HTML or JavaScript payloads are neutralized and rendered safely as text.
✅ **Verification**: Code syntax checked with `php -l bills.php` and automated test suite ran successfully via `phpunit`. Added a journal entry to `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [10660743774882973699](https://jules.google.com/task/10660743774882973699) started by @AdarshaCR001*