### PR TITLE
🎨 Palette: Improve login accessibility and feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-06-13 - [Custom Validation, Loading States, and Modal Accessibility]
 **Learning:** Found that custom validation using jQuery is needed to prevent default browser validation UI from showing up. Also learned that when using SweetAlert for confirmations, moving the button state change into the `.then(result => { if (result.isConfirmed) { ... } })` block is safer than changing it beforehand, otherwise you need to handle the state reset in the `else` block if the user cancels.
 **Action:** When adding validation or loading states to jQuery-based forms, always set `novalidate` on the form tag to suppress the browser UI, and carefully scope the loading state updates to the confirmed path of any prompt dialogs.
+
+## 2026-07-02 - [Login Micro-UX Accessibility and Feedback]
+**Learning:** Found that when pages don't load jQuery (like `login.php`), we must rely on native HTML attributes (`autofocus`, `.sr-only` class) and vanilla JS for state management. The inline `onsubmit` handler is an effective lightweight approach for preventing double submissions while giving immediate feedback ("Logging in...").
+**Action:** Use native HTML5 attributes like `autofocus` combined with `.sr-only` labels to enhance immediate accessibility without adding overhead on non-jQuery pages, and use simple vanilla JS onsubmit handlers to handle immediate state feedback.

--- a/login.php
+++ b/login.php
@@ -87,8 +87,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <?php if ($error): ?>
             <div class="error-message"><?php echo htmlspecialchars($error); ?></div>
         <?php endif; ?>
-        <form method="POST">
-            <input type="password" name="password" class="form-control" placeholder="Enter Password" required>
+        <form method="POST" onsubmit="var btn = this.querySelector('button[type=submit]'); btn.disabled = true; btn.innerText = 'Logging in...';">
+            <label for="password" class="sr-only">Password</label>
+            <input type="password" id="password" name="password" class="form-control" placeholder="Enter Password" required autofocus>
             <button type="submit" class="btn btn-primary">Login</button>
         </form>
     </div>


### PR DESCRIPTION
💡 **What:** 
- Added a `<label>` with `.sr-only` targeting the password input for screen readers.
- Added `autofocus` to the password input so users can begin typing immediately.
- Added an inline `onsubmit` handler to disable the submit button and change the text to "Logging in..." upon form submission.

🎯 **Why:** 
The login page is the primary entry point and its form interactions lacked basic micro-UX improvements. Adding autofocus saves an initial click, providing immediate feedback during submission prevents confusion or double clicks, and the sr-only label ensures screen readers can announce the field context clearly.

📸 **Before/After:** 
(See verified screenshots)

♿ **Accessibility:** 
- Screen readers will now announce "Password" when the input receives focus.
- Visual state changes inform users that their form submission is processing.

---
*PR created automatically by Jules for task [9043499852281291821](https://jules.google.com/task/9043499852281291821) started by @AdarshaCR001*