### PR TITLE
🎨 Palette: Improve Login UX with autofocus, labels, and loading state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-06-13 - [Custom Validation, Loading States, and Modal Accessibility]
 **Learning:** Found that custom validation using jQuery is needed to prevent default browser validation UI from showing up. Also learned that when using SweetAlert for confirmations, moving the button state change into the `.then(result => { if (result.isConfirmed) { ... } })` block is safer than changing it beforehand, otherwise you need to handle the state reset in the `else` block if the user cancels.
 **Action:** When adding validation or loading states to jQuery-based forms, always set `novalidate` on the form tag to suppress the browser UI, and carefully scope the loading state updates to the confirmed path of any prompt dialogs.
+## 2026-07-03 - [Vanilla JS Micro-UX on Login]
+**Learning:** Found that standalone pages without jQuery (like login screens) benefit immensely from simple inline vanilla JS (`onsubmit`) to handle loading states and prevent double submissions. Also, `autofocus` combined with `.sr-only` labels provides an immediate accessibility and usability boost without requiring CSS changes.
+**Action:** Always add semantic `<label>` elements (even if visually hidden), `autofocus` to the primary input, and loading state handlers to standalone authentication pages.

--- a/login.php
+++ b/login.php
@@ -87,8 +87,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <?php if ($error): ?>
             <div class="error-message"><?php echo htmlspecialchars($error); ?></div>
         <?php endif; ?>
-        <form method="POST">
-            <input type="password" name="password" class="form-control" placeholder="Enter Password" required>
+        <form method="POST" onsubmit="var btn=this.querySelector('button[type=submit]'); btn.disabled=true; btn.innerText='Logging in...'; return true;">
+            <label for="password" class="sr-only">Password</label>
+            <input type="password" id="password" name="password" class="form-control" placeholder="Enter Password" required autofocus>
             <button type="submit" class="btn btn-primary">Login</button>
         </form>
     </div>


### PR DESCRIPTION
💡 What: Added micro-UX improvements to the standalone login page (`login.php`). This includes a screen-reader-only `<label>`, `autofocus` on the password input, and an inline `onsubmit` handler that changes the button text to "Logging in..." and disables it upon submission.
🎯 Why: It solves several small usability and accessibility issues. The lack of a label affects screen reader users, the lack of autofocus requires an extra click to start typing on a single-input page, and the lack of a loading state could cause users to click multiple times leading to confusion.
📸 Before/After: Visual hierarchy unchanged. Playwright tests confirmed the active element starts on the password field instead of the body.
♿ Accessibility: Improved via the inclusion of a `<label for="password">` element hidden visually using Bootstrap's `.sr-only` class.

Also added a journal entry for these specific learnings.

---
*PR created automatically by Jules for task [478372121176068905](https://jules.google.com/task/478372121176068905) started by @AdarshaCR001*