### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in Bills view

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [HIGH] Fix Stored XSS in Bills view
+**Vulnerability:** String fields like `invoice_number`, `buyer_company`, `buyer_address`, `item_name`, `vehicle_number`, `url`, `bag`, and `quantity` retrieved from the database were being directly echoed into the HTML view without any HTML escaping in `bills.php`. This leaves the application highly vulnerable to Stored Cross-Site Scripting (XSS) if any malicious HTML or JavaScript is saved to the database.
+**Learning:** Even if data is fetched using secure prepared statements, it still needs to be properly escaped when presented in views to prevent XSS.
+**Prevention:** Always wrap unescaped string data retrieved from the database with `htmlspecialchars()` before echoing it directly into HTML templates.

--- a/bills.php
+++ b/bills.php
@@ -831,23 +831,23 @@ function getPaginationLink($p, $buyer_filter, $balance_filter) {
                 <?php if (count($result) > 0) { ?>
             <?php foreach ($result as $row) { ?>
                 <tr>
-                    <td><?php echo $row['invoice_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['invoice_number']); ?></td>
                     <td><?php echo htmlspecialchars(date('Y-m-d', strtotime($row['created_on']))); ?></td>
-                    <td><?php echo $row['buyer_company']; ?></td>
-                    <td><?php echo $row['buyer_address']; ?></td>
-                    <td><?php echo $row['item_name']; ?></td>
-                    <td><?php echo $row['bag']; ?></td>
-                    <td><?php echo $row['quantity']; ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_company']); ?></td>
+                    <td><?php echo htmlspecialchars($row['buyer_address']); ?></td>
+                    <td><?php echo htmlspecialchars($row['item_name']); ?></td>
+                    <td><?php echo htmlspecialchars($row['bag']); ?></td>
+                    <td><?php echo htmlspecialchars($row['quantity']); ?></td>
                     <td><?php echo formatIndianCurrency($row['price']); ?></td>
                     <td><?php echo formatIndianCurrency($row['price'] * $row['quantity']); ?></td>
-                    <td><?php echo $row['vehicle_number']; ?></td>
+                    <td><?php echo htmlspecialchars($row['vehicle_number']); ?></td>
                     <td><?php echo formatIndianCurrency($row['vehicle_freight']); ?></td>
                     <td>
                         <div style="font-weight: 600; margin-bottom: 6px;"><?php echo formatIndianCurrency($row['balance'] !== null ? $row['balance'] : 0.00); ?></div>
                         <button class="btn btn-info" onclick="editBalance(<?php echo htmlspecialchars(json_encode($row)); ?>)" style="padding: 2px 8px !important; height: 22px !important; font-size: 10px !important; font-weight: 600 !important; border-radius: 4px !important; margin: 0 !important; line-height: 1 !important; display: inline-flex !important; align-items: center !important;">Edit Balance</button>
                     </td>
                     <td class="actions-cell">
-                        <a class="file-download" href="<?php echo $row['url']; ?>" target="_blank" download>Download</a>
+                        <a class="file-download" href="<?php echo htmlspecialchars($row['url']); ?>" target="_blank" download>Download</a>
                         <button class="btn btn-warning" onclick="editBill(<?php echo htmlspecialchars(json_encode($row)); ?>)">Edit</button>
                     </td>
                 </tr>


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: String fields retrieved from the database were being echoed into the HTML view without HTML escaping in `bills.php`.
- 🎯 Impact: High risk of Stored Cross-Site Scripting (XSS) if malicious HTML or JavaScript is saved to the database.
- 🔧 Fix: Added `htmlspecialchars()` to directly echoed `$row` string fields (e.g. `invoice_number`, `buyer_company`, `buyer_address`, `item_name`, `vehicle_number`, `url`, `bag`, `quantity`).
- ✅ Verification: Ran the PHPUnit test suite to ensure no regressions were introduced and manually confirmed the syntax using `php -l bills.php`.

---
*PR created automatically by Jules for task [6377953853751337023](https://jules.google.com/task/6377953853751337023) started by @AdarshaCR001*