### PR TITLE
🎨 Palette: Improve login form accessibility and interaction

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-06-13 - [Custom Validation, Loading States, and Modal Accessibility]
 **Learning:** Found that custom validation using jQuery is needed to prevent default browser validation UI from showing up. Also learned that when using SweetAlert for confirmations, moving the button state change into the `.then(result => { if (result.isConfirmed) { ... } })` block is safer than changing it beforehand, otherwise you need to handle the state reset in the `else` block if the user cancels.
 **Action:** When adding validation or loading states to jQuery-based forms, always set `novalidate` on the form tag to suppress the browser UI, and carefully scope the loading state updates to the confirmed path of any prompt dialogs.
+## 2024-05-24 - Login Form Accessibility and Interaction Improvements
+**Learning:** Native HTML attributes like `autofocus` and vanilla JS inline `onsubmit` handlers are incredibly powerful for micro-UX improvements on pages that don't load external libraries like jQuery. The `.sr-only` class is essential for screen reader support on visual-only inputs, allowing accessibility without disrupting visual flow.
+**Action:** When working on standalone or minimalist pages, prioritize native HTML/JS features for state management and focus, and always map inputs to `.sr-only` labels to ensure full accessibility.

--- a/login.php
+++ b/login.php
@@ -87,8 +87,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <?php if ($error): ?>
             <div class="error-message"><?php echo htmlspecialchars($error); ?></div>
         <?php endif; ?>
-        <form method="POST">
-            <input type="password" name="password" class="form-control" placeholder="Enter Password" required>
+        <form method="POST" onsubmit="var b=this.querySelector('button[type=submit]');b.disabled=true;b.textContent='Logging in...';">
+            <label for="password" class="sr-only">Password</label>
+            <input type="password" id="password" name="password" class="form-control" placeholder="Enter Password" required autofocus>
             <button type="submit" class="btn btn-primary">Login</button>
         </form>
     </div>


### PR DESCRIPTION
💡 What: Added `id="password"`, `autofocus`, and a visually hidden `<label>` to the login form, along with an inline `onsubmit` handler to disable the submit button and change its text to "Logging in...".
🎯 Why: Improves screen reader accessibility, allows immediate typing upon page load, and provides immediate visual feedback to the user upon submission, preventing double-clicks.
📸 Before/After: Visual changes verified via Playwright.
♿ Accessibility: Mapped the input to a `.sr-only` label for screen readers. Added `autofocus` to save a click.

---
*PR created automatically by Jules for task [11514033390937482009](https://jules.google.com/task/11514033390937482009) started by @AdarshaCR001*