### PR TITLE
Fix CSV deprecation warning and add Total Amount column

### DIFF
--- a/bills.php
+++ b/bills.php
@@ -904,9 +904,9 @@ function getExportCsvLink($buyer_filter, $balance_filter, $selected_month, $sele
                     <th>Bag</th>
                     <th>Quantity (KG)</th>
                     <th>Price (per KG)</th>
-                    <th>Amount</th>
                     <th>Vehicle Number</th>
                     <th>Vehicle Freight</th>
+                    <th>Total Amount</th>
                     <th>Payment Status</th>
                     <th class="actions-header">Actions</th>
                 </tr>
@@ -923,9 +923,9 @@ function getExportCsvLink($buyer_filter, $balance_filter, $selected_month, $sele
                     <td><?php echo htmlspecialchars($row['bag']); ?></td>
                     <td><?php echo htmlspecialchars($row['quantity']); ?></td>
                     <td><?php echo htmlspecialchars(formatIndianCurrency($row['price'])); ?></td>
-                    <td><?php echo htmlspecialchars(formatIndianCurrency($row['price'] * $row['quantity'])); ?></td>
                     <td><?php echo htmlspecialchars($row['vehicle_number']); ?></td>
                     <td><?php echo htmlspecialchars(formatIndianCurrency($row['vehicle_freight'])); ?></td>
+                    <td><?php echo htmlspecialchars(formatIndianCurrency(($row['price'] * $row['quantity']) + $row['vehicle_freight'])); ?></td>
                     <td>
                         <div style="font-size: 11px; color: var(--text-muted); margin-bottom: 2px;">Paid: <?php echo htmlspecialchars(formatIndianCurrency($row['payment_received'] !== null ? $row['payment_received'] : 0.00)); ?></div>
                         <div style="font-weight: 600; margin-bottom: 6px; color: <?php echo $row['balance'] > 0 ? '#f87171' : 'inherit'; ?>;">Bal: <?php echo htmlspecialchars(formatIndianCurrency($row['balance'] !== null ? $row['balance'] : 0.00)); ?></div>

--- a/export_bills_csv.php
+++ b/export_bills_csv.php
@@ -75,16 +75,16 @@ try {
         'Bag',
         'Quantity (KG)',
         'Price (per KG)',
-        'Amount',
         'Vehicle Number',
         'Vehicle Freight',
+        'Total Amount',
         'Payment Received',
         'Balance'
-    ]);
+    ], ",", '"', "\\");
 
     foreach ($bills as $row) {
         $invoiceDate = date('Y-m-d', strtotime($row['created_on']));
-        $amount = $row['price'] * $row['quantity'];
+        $totalAmount = ($row['price'] * $row['quantity']) + $row['vehicle_freight'];
         $balance = $row['balance'] !== null ? $row['balance'] : 0.00;
 
         fputcsv($output, [
@@ -96,12 +96,12 @@ try {
             $row['bag'],
             $row['quantity'],
             formatIndianCurrency($row['price']),
-            formatIndianCurrency($amount),
             $row['vehicle_number'],
             formatIndianCurrency($row['vehicle_freight']),
+            formatIndianCurrency($totalAmount),
             formatIndianCurrency($row['payment_received'] !== null ? $row['payment_received'] : 0.00),
             formatIndianCurrency($balance)
-        ]);
+        ], ",", '"', "\\");
     }
 
     fclose($output);


### PR DESCRIPTION
Fixed PHP fputcsv() deprecation warning in export_bills_csv.php by passing explicit enclosure and escape character arguments. Updated bills.php and export_bills_csv.php to replace the "Amount" column with "Total Amount" calculated as (quantity * price) + vehicle_freight, placed directly after "Vehicle Freight".

---
*PR created automatically by Jules for task [14725200371181715267](https://jules.google.com/task/14725200371181715267) started by @AdarshaCR001*